### PR TITLE
Correct read header before using.

### DIFF
--- a/redupe.c
+++ b/redupe.c
@@ -925,6 +925,12 @@ redupe_correct_read(struct redupe_correct_file* in, unsigned char* buf, size_t b
             in->offset = 0;
             unsigned char header[256];
             gather(in->chunk, header, BLOCK_SIZE - 1);
+
+            if (redupe_correct_msg(header, HEADER_SIZE, 255 - HEADER_SIZE, header + HEADER_SIZE) < 0)
+            {
+                return -1;
+            }
+
             unsigned long long chunk_amt;
             parse_header(header, &chunk_amt, &in->msg_sz, &in->code_sz);
             in->chunk_amt = chunk_amt;


### PR DESCRIPTION
This fixes assertion failure if a header byte is corrupted. There is enough redundancy to recover the header.
```
$ ./redupe </tmp/file >/tmp/encode
$ cat /dev/urandom | dd of=/tmp/encode bs=1 seek=4095 count=1 conv=notrunc
$ ./reundupe </tmp/encode | pv >/tmp/restore
reundupe: redupe.c:931: redupe_correct_read: Assertion `in->chunk_amt == chunk_amt' failed.
```